### PR TITLE
Fix: swipe card overflow in details section

### DIFF
--- a/lib/features/discover/presentation/widgets/swipe_card_details_section.dart
+++ b/lib/features/discover/presentation/widgets/swipe_card_details_section.dart
@@ -398,19 +398,29 @@ class SwipeCardDetailsSection extends StatelessWidget {
     return Padding(
       padding: const EdgeInsets.only(bottom: 8),
       child: Row(
-        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Text(
-            label,
-            style: theme.textTheme.bodyMedium?.copyWith(
-              color: colorScheme.onSurface.withValues(alpha: 0.6),
+          Flexible(
+            flex: 2,
+            child: Text(
+              label,
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: colorScheme.onSurface.withValues(alpha: 0.6),
+              ),
             ),
           ),
-          Text(
-            value,
-            style: theme.textTheme.bodyMedium?.copyWith(
-              fontWeight: FontWeight.w600,
-              color: colorScheme.onSurface,
+          const SizedBox(width: 12),
+          Flexible(
+            flex: 3,
+            child: Text(
+              value,
+              maxLines: 2,
+              overflow: TextOverflow.ellipsis,
+              textAlign: TextAlign.right,
+              style: theme.textTheme.bodyMedium?.copyWith(
+                fontWeight: FontWeight.w600,
+                color: colorScheme.onSurface,
+              ),
             ),
           ),
         ],


### PR DESCRIPTION
## Problem
`_buildDetailRow` in `swipe_card_details_section.dart` rendered both label 
and value as unconstrained `Text` widgets inside a `Row`. Long values like 
property addresses caused a RenderFlex overflow across all 12 detail rows 
(location, builder, parking, distance, floor, age, etc.).

## Root Cause
- No `Flexible` or `Expanded` on either `Text` child
- No `maxLines` or `TextOverflow` on the value
- `MainAxisAlignment.spaceBetween` with unconstrained children → overflow

## Fix
- Wrapped label in `Flexible(flex: 2)` — 40% of row width
- Wrapped value in `Flexible(flex: 3)` — 60% of row width  
- Added `crossAxisAlignment: CrossAxisAlignment.start` for multi-line alignment
- Added `SizedBox(width: 12)` between label and value
- Added `maxLines: 2` + `TextOverflow.ellipsis` on value

## Scope
Single method fix — all 12 `_buildDetailRow` call sites are covered.

Closes #<issue-number>

<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/360ghar/360-ghar-app/pull/25">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes text overflow in the swipe card details section. Long values (like addresses) no longer break the layout across all detail rows.

- **Bug Fixes**
  - Constrained label and value with Flexible (2/3 split).
  - Added maxLines: 2 and ellipsis to value; right-aligned value text.
  - Added 12px gap and set crossAxisAlignment.start for clean multi-line alignment.

<sup>Written for commit 88fd29638b3a43002beb4e7323112f0f15466ae3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/360ghar/360-ghar-app/pull/25?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the layout of swipe card detail rows so long values no longer overflow or crowd the label.
  * Detail values now wrap to two lines with ellipsis when needed, keeping the card easier to read on smaller screens.
  * Added consistent spacing and right-aligned value text for a cleaner, more balanced presentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->