### PR TITLE
fix: add SafeArea support to filter bottom sheet

### DIFF
--- a/lib/core/widgets/common/property_filter_widget.dart
+++ b/lib/core/widgets/common/property_filter_widget.dart
@@ -1,7 +1,5 @@
 import 'package:flutter/material.dart';
-
 import 'package:get/get.dart';
-
 import 'package:ghar360/core/controllers/page_state_service.dart';
 import 'package:ghar360/core/data/models/unified_filter_model.dart';
 import 'package:ghar360/core/design/app_design_extensions.dart';
@@ -26,6 +24,7 @@ class PropertyFilterWidget extends StatelessWidget {
       context: context,
       isScrollControlled: true,
       backgroundColor: AppDesign.transparent,
+      useSafeArea: true,
       builder: (context) =>
           _FilterBottomSheet(pageType: pageType, onFiltersApplied: onFiltersApplied),
     );
@@ -645,52 +644,54 @@ class _FilterBottomSheetState extends State<_FilterBottomSheet> {
   }
 
   Widget _buildActionButtons() {
-    return Container(
-      padding: const EdgeInsets.all(20),
-      decoration: BoxDecoration(
-        border: Border(top: BorderSide(color: AppDesign.border, width: 0.2)),
-      ),
-      child: Row(
-        children: [
-          Expanded(
-            child: OutlinedButton(
-              onPressed: _clearFilters,
-              style: OutlinedButton.styleFrom(
-                padding: const EdgeInsets.symmetric(vertical: 16),
-                side: const BorderSide(color: AppDesign.primaryYellow),
-                shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
-              ),
-              child: Text(
-                'clear_filters'.tr,
-                style: const TextStyle(
-                  fontSize: 16,
-                  color: AppDesign.primaryYellow,
-                  fontWeight: FontWeight.w600,
+    return SafeArea(
+      child: Container(
+        padding: const EdgeInsets.all(20),
+        decoration: BoxDecoration(
+          border: Border(top: BorderSide(color: AppDesign.border, width: 0.2)),
+        ),
+        child: Row(
+          children: [
+            Expanded(
+              child: OutlinedButton(
+                onPressed: _clearFilters,
+                style: OutlinedButton.styleFrom(
+                  padding: const EdgeInsets.symmetric(vertical: 16),
+                  side: const BorderSide(color: AppDesign.primaryYellow),
+                  shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+                ),
+                child: Text(
+                  'clear_filters'.tr,
+                  style: const TextStyle(
+                    fontSize: 16,
+                    color: AppDesign.primaryYellow,
+                    fontWeight: FontWeight.w600,
+                  ),
                 ),
               ),
             ),
-          ),
-          const SizedBox(width: 16),
-          Expanded(
-            flex: 2,
-            child: ElevatedButton(
-              onPressed: _applyFilters,
-              style: ElevatedButton.styleFrom(
-                backgroundColor: AppDesign.primaryYellow,
-                padding: const EdgeInsets.symmetric(vertical: 16),
-                shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
-              ),
-              child: Text(
-                'apply_filters'.tr,
-                style: TextStyle(
-                  fontSize: 16,
-                  color: AppDesign.surface,
-                  fontWeight: FontWeight.w600,
+            const SizedBox(width: 16),
+            Expanded(
+              flex: 2,
+              child: ElevatedButton(
+                onPressed: _applyFilters,
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: AppDesign.primaryYellow,
+                  padding: const EdgeInsets.symmetric(vertical: 16),
+                  shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+                ),
+                child: Text(
+                  'apply_filters'.tr,
+                  style: TextStyle(
+                    fontSize: 16,
+                    color: AppDesign.surface,
+                    fontWeight: FontWeight.w600,
+                  ),
                 ),
               ),
             ),
-          ),
-        ],
+          ],
+        ),
       ),
     );
   }
@@ -840,6 +841,7 @@ void showPropertyFilterBottomSheet(
     context: context,
     isScrollControlled: true,
     backgroundColor: AppDesign.transparent,
+    useSafeArea: true,
     builder: (ctx) => _FilterBottomSheet(pageType: pageType, onFiltersApplied: onFiltersApplied),
   );
 }

--- a/lib/features/discover/presentation/widgets/swipe_card_details_section.dart
+++ b/lib/features/discover/presentation/widgets/swipe_card_details_section.dart
@@ -398,19 +398,29 @@ class SwipeCardDetailsSection extends StatelessWidget {
     return Padding(
       padding: const EdgeInsets.only(bottom: 8),
       child: Row(
-        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Text(
-            label,
-            style: theme.textTheme.bodyMedium?.copyWith(
-              color: colorScheme.onSurface.withValues(alpha: 0.6),
+          Flexible(
+            flex: 2,
+            child: Text(
+              label,
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: colorScheme.onSurface.withValues(alpha: 0.6),
+              ),
             ),
           ),
-          Text(
-            value,
-            style: theme.textTheme.bodyMedium?.copyWith(
-              fontWeight: FontWeight.w600,
-              color: colorScheme.onSurface,
+          const SizedBox(width: 12),
+          Flexible(
+            flex: 3,
+            child: Text(
+              value,
+              maxLines: 2,
+              overflow: TextOverflow.ellipsis,
+              textAlign: TextAlign.right,
+              style: theme.textTheme.bodyMedium?.copyWith(
+                fontWeight: FontWeight.w600,
+                color: colorScheme.onSurface,
+              ),
             ),
           ),
         ],


### PR DESCRIPTION
Device navigation bar was overlapping the Clear Filters and Apply Filters 
buttons on gesture-navigation devices.

Changes in property_filter_widget.dart:
- Added useSafeArea: true to both showModalBottomSheet invocations (lines 27, 844)
- Wrapped _buildActionButtons() in SafeArea as defense-in-depth (line 646)

Fixes all 6 call sites (discover, likes, explore, unified top bar) automatically.



<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/360ghar/360-ghar-app/pull/26">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds SafeArea support to the property filter bottom sheet so the navigation bar no longer overlaps the Clear/Apply buttons on gesture-navigation devices. Also fixes text overflow in the swipe card details row.

- **Bug Fixes**
  - Enabled `useSafeArea: true` for both `showModalBottomSheet` calls in the shared filter widget, covering all entry points.
  - Wrapped the action button bar in `SafeArea` for defense-in-depth.
  - Adjusted `SwipeCardDetailsSection` layout with `Flexible`, spacing, and ellipsis to prevent overflow and align text.

<sup>Written for commit 23947dffef1d3d3615b08c4bfbfbc4b08ee91e2b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/360ghar/360-ghar-app/pull/26?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

