### PR TITLE
Fix/visits controller double init

### DIFF
--- a/lib/core/widgets/common/property_filter_widget.dart
+++ b/lib/core/widgets/common/property_filter_widget.dart
@@ -1,7 +1,5 @@
 import 'package:flutter/material.dart';
-
 import 'package:get/get.dart';
-
 import 'package:ghar360/core/controllers/page_state_service.dart';
 import 'package:ghar360/core/data/models/unified_filter_model.dart';
 import 'package:ghar360/core/design/app_design_extensions.dart';
@@ -26,6 +24,7 @@ class PropertyFilterWidget extends StatelessWidget {
       context: context,
       isScrollControlled: true,
       backgroundColor: AppDesign.transparent,
+      useSafeArea: true,
       builder: (context) =>
           _FilterBottomSheet(pageType: pageType, onFiltersApplied: onFiltersApplied),
     );
@@ -645,52 +644,54 @@ class _FilterBottomSheetState extends State<_FilterBottomSheet> {
   }
 
   Widget _buildActionButtons() {
-    return Container(
-      padding: const EdgeInsets.all(20),
-      decoration: BoxDecoration(
-        border: Border(top: BorderSide(color: AppDesign.border, width: 0.2)),
-      ),
-      child: Row(
-        children: [
-          Expanded(
-            child: OutlinedButton(
-              onPressed: _clearFilters,
-              style: OutlinedButton.styleFrom(
-                padding: const EdgeInsets.symmetric(vertical: 16),
-                side: const BorderSide(color: AppDesign.primaryYellow),
-                shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
-              ),
-              child: Text(
-                'clear_filters'.tr,
-                style: const TextStyle(
-                  fontSize: 16,
-                  color: AppDesign.primaryYellow,
-                  fontWeight: FontWeight.w600,
+    return SafeArea(
+      child: Container(
+        padding: const EdgeInsets.all(20),
+        decoration: BoxDecoration(
+          border: Border(top: BorderSide(color: AppDesign.border, width: 0.2)),
+        ),
+        child: Row(
+          children: [
+            Expanded(
+              child: OutlinedButton(
+                onPressed: _clearFilters,
+                style: OutlinedButton.styleFrom(
+                  padding: const EdgeInsets.symmetric(vertical: 16),
+                  side: const BorderSide(color: AppDesign.primaryYellow),
+                  shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+                ),
+                child: Text(
+                  'clear_filters'.tr,
+                  style: const TextStyle(
+                    fontSize: 16,
+                    color: AppDesign.primaryYellow,
+                    fontWeight: FontWeight.w600,
+                  ),
                 ),
               ),
             ),
-          ),
-          const SizedBox(width: 16),
-          Expanded(
-            flex: 2,
-            child: ElevatedButton(
-              onPressed: _applyFilters,
-              style: ElevatedButton.styleFrom(
-                backgroundColor: AppDesign.primaryYellow,
-                padding: const EdgeInsets.symmetric(vertical: 16),
-                shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
-              ),
-              child: Text(
-                'apply_filters'.tr,
-                style: TextStyle(
-                  fontSize: 16,
-                  color: AppDesign.surface,
-                  fontWeight: FontWeight.w600,
+            const SizedBox(width: 16),
+            Expanded(
+              flex: 2,
+              child: ElevatedButton(
+                onPressed: _applyFilters,
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: AppDesign.primaryYellow,
+                  padding: const EdgeInsets.symmetric(vertical: 16),
+                  shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+                ),
+                child: Text(
+                  'apply_filters'.tr,
+                  style: TextStyle(
+                    fontSize: 16,
+                    color: AppDesign.surface,
+                    fontWeight: FontWeight.w600,
+                  ),
                 ),
               ),
             ),
-          ),
-        ],
+          ],
+        ),
       ),
     );
   }
@@ -840,6 +841,7 @@ void showPropertyFilterBottomSheet(
     context: context,
     isScrollControlled: true,
     backgroundColor: AppDesign.transparent,
+    useSafeArea: true,
     builder: (ctx) => _FilterBottomSheet(pageType: pageType, onFiltersApplied: onFiltersApplied),
   );
 }

--- a/lib/features/discover/presentation/widgets/swipe_card_details_section.dart
+++ b/lib/features/discover/presentation/widgets/swipe_card_details_section.dart
@@ -398,19 +398,29 @@ class SwipeCardDetailsSection extends StatelessWidget {
     return Padding(
       padding: const EdgeInsets.only(bottom: 8),
       child: Row(
-        mainAxisAlignment: MainAxisAlignment.spaceBetween,
+        crossAxisAlignment: CrossAxisAlignment.start,
         children: [
-          Text(
-            label,
-            style: theme.textTheme.bodyMedium?.copyWith(
-              color: colorScheme.onSurface.withValues(alpha: 0.6),
+          Flexible(
+            flex: 2,
+            child: Text(
+              label,
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: colorScheme.onSurface.withValues(alpha: 0.6),
+              ),
             ),
           ),
-          Text(
-            value,
-            style: theme.textTheme.bodyMedium?.copyWith(
-              fontWeight: FontWeight.w600,
-              color: colorScheme.onSurface,
+          const SizedBox(width: 12),
+          Flexible(
+            flex: 3,
+            child: Text(
+              value,
+              maxLines: 2,
+              overflow: TextOverflow.ellipsis,
+              textAlign: TextAlign.right,
+              style: theme.textTheme.bodyMedium?.copyWith(
+                fontWeight: FontWeight.w600,
+                color: colorScheme.onSurface,
+              ),
             ),
           ),
         ],

--- a/lib/features/visits/presentation/bindings/visits_binding.dart
+++ b/lib/features/visits/presentation/bindings/visits_binding.dart
@@ -1,10 +1,11 @@
 import 'package:get/get.dart';
-
 import 'package:ghar360/features/visits/presentation/controllers/visits_controller.dart';
 
 class VisitsBinding extends Bindings {
   @override
   void dependencies() {
-    Get.lazyPut<VisitsController>(() => VisitsController());
+    if (!Get.isRegistered<VisitsController>()) {
+      Get.lazyPut<VisitsController>(() => VisitsController());
+    }
   }
 }

--- a/lib/features/visits/presentation/controllers/visits_controller.dart
+++ b/lib/features/visits/presentation/controllers/visits_controller.dart
@@ -1,7 +1,5 @@
 import 'package:flutter/widgets.dart';
-
 import 'package:get/get.dart';
-
 import 'package:ghar360/core/controllers/auth_controller.dart';
 import 'package:ghar360/core/controllers/offline_queue_service.dart';
 import 'package:ghar360/core/data/models/agent_model.dart';
@@ -17,8 +15,8 @@ import 'package:ghar360/features/visits/data/datasources/visits_remote_datasourc
 class VisitsController extends GetxController {
   static const int _visitPageSize = 25;
 
-  late final VisitsRemoteDatasource _visitsRemoteDatasource;
-  late final AuthController _authController;
+  late VisitsRemoteDatasource _visitsRemoteDatasource;
+  late AuthController _authController;
 
   final RxList<VisitModel> visits = <VisitModel>[].obs;
   final RxList<VisitModel> upcomingVisitsList = <VisitModel>[].obs;


### PR DESCRIPTION
## Summary
Fixes #27

Two-part fix for `LateInitializationError` caused by `VisitsController` being 
instantiated twice when navigating between Visits tab and Property Details.

Adds an `isRegistered` guard to `VisitsBinding` to prevent `VisitsController` 
from being registered twice, which caused `onInit()` to fire twice and crash 
on the `late final _visitsRemoteDatasource` field.
## Changes

**`lib/features/visits/presentation/bindings/visits_binding.dart`**
- Added `isRegistered` guard around `Get.lazyPut<VisitsController>` to prevent 
  duplicate factory registration

**`lib/features/visits/presentation/controllers/visits_controller.dart`**
- Changed `late final _visitsRemoteDatasource` to `late` to prevent crash if 
  `onInit()` fires twice (defensive fallback)


<!-- stage-review-badge-begin -->

---

<a href="https://stagereview.app/360ghar/360-ghar-app/pull/28">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://stagereview.app/assets/gh-open-in-stage-dark.svg">
    <img src="https://stagereview.app/assets/gh-open-in-stage-light.svg" alt="Open in Stage">
  </picture>
</a>

<!-- stage-review-badge-end -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents double initialization of `VisitsController` that caused a LateInitializationError when switching between Visits and Property Details. Also fixes bottom sheet safe area clipping and swipe card text overflow.

- **Bug Fixes**
  - Guard `VisitsBinding` with `Get.isRegistered` to avoid duplicate `Get.lazyPut` registration.
  - Change `_visitsRemoteDatasource` and `_authController` from `late final` to `late` as a defensive fallback if `onInit` runs twice.
  - Property filter bottom sheet: add `useSafeArea: true` and wrap action buttons in `SafeArea`.
  - Swipe card details: use `Flexible` and ellipsis to prevent overflow and align content.

<sup>Written for commit 51a05f630e8192313a7f5e9fc5b74b500fc65717. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/360ghar/360-ghar-app/pull/28?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bottom-sheet behavior so filter actions respect device safe areas and display more consistently on notched or inset screens.
  * Prevented layout overflow in swipe card details by better handling long text and keeping labels/values aligned.
  * Fixed a visits screen setup issue by avoiding duplicate controller registration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->